### PR TITLE
Add Codex 80s racing game

### DIFF
--- a/model_tests/Codex/80s_Racing_Game/README.md
+++ b/model_tests/Codex/80s_Racing_Game/README.md
@@ -1,0 +1,5 @@
+# 80s Racing Game
+
+A simple top-down racing game inspired by classic 1980s arcade racers. Use the left and right arrow keys to avoid oncoming cars and stay on the road.
+
+Open `index.html` in a web browser to play.

--- a/model_tests/Codex/80s_Racing_Game/index.html
+++ b/model_tests/Codex/80s_Racing_Game/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>80s Racing Game</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <canvas id="gameCanvas" width="400" height="600"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/model_tests/Codex/80s_Racing_Game/script.js
+++ b/model_tests/Codex/80s_Racing_Game/script.js
@@ -1,0 +1,102 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+
+const road = { left: 50, width: 300 };
+const player = { x: canvas.width / 2 - 20, y: canvas.height - 100, width: 40, height: 80, speed: 5 };
+let keys = { left: false, right: false };
+let lines = [];
+let cars = [];
+let frame = 0;
+
+function createLine(y) {
+  return { x: canvas.width / 2 - 5, y, width: 10, height: 40 };
+}
+
+for (let i = 0; i < 20; i++) {
+  lines.push(createLine(i * 60));
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'ArrowLeft') keys.left = true;
+  if (e.key === 'ArrowRight') keys.right = true;
+});
+
+document.addEventListener('keyup', e => {
+  if (e.key === 'ArrowLeft') keys.left = false;
+  if (e.key === 'ArrowRight') keys.right = false;
+});
+
+function update() {
+  frame++;
+
+  // Move lane lines
+  lines.forEach(line => {
+    line.y += 10;
+    if (line.y > canvas.height) {
+      line.y = -line.height;
+    }
+  });
+
+  // Spawn enemy cars
+  if (frame % 60 === 0) {
+    const lane = Math.floor(Math.random() * 3);
+    cars.push({
+      x: road.left + 20 + lane * 90,
+      y: -100,
+      width: 40,
+      height: 80,
+      speed: 6
+    });
+  }
+
+  cars.forEach(car => {
+    car.y += car.speed;
+  });
+
+  cars = cars.filter(car => car.y < canvas.height + 100);
+
+  // Player movement
+  if (keys.left) player.x -= player.speed;
+  if (keys.right) player.x += player.speed;
+  player.x = Math.max(road.left, Math.min(player.x, road.left + road.width - player.width));
+
+  // Collision detection
+  for (const car of cars) {
+    if (
+      player.x < car.x + car.width &&
+      player.x + player.width > car.x &&
+      player.y < car.y + car.height &&
+      player.y + player.height > car.y
+    ) {
+      alert('Game Over!');
+      document.location.reload();
+      return;
+    }
+  }
+
+  draw();
+  requestAnimationFrame(update);
+}
+
+function draw() {
+  ctx.fillStyle = '#444';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Road
+  ctx.fillStyle = '#111';
+  ctx.fillRect(road.left, 0, road.width, canvas.height);
+
+  // Lane lines
+  ctx.fillStyle = '#fff';
+  lines.forEach(line => ctx.fillRect(line.x, line.y, line.width, line.height));
+
+  // Player
+  ctx.fillStyle = '#0f0';
+  ctx.fillRect(player.x, player.y, player.width, player.height);
+
+  // Enemy cars
+  ctx.fillStyle = '#f00';
+  cars.forEach(car => ctx.fillRect(car.x, car.y, car.width, car.height));
+}
+
+update();

--- a/model_tests/Codex/80s_Racing_Game/styles.css
+++ b/model_tests/Codex/80s_Racing_Game/styles.css
@@ -1,0 +1,11 @@
+body {
+  margin: 0;
+  background: #222;
+  display: flex;
+  justify-content: center;
+}
+
+canvas {
+  background: #555;
+  border: 2px solid #fff;
+}

--- a/model_tests/Codex/README.md
+++ b/model_tests/Codex/README.md
@@ -1,0 +1,7 @@
+# Codex
+
+Projects generated with the Codex model.
+
+## Included
+
+- 80s Racing Game

--- a/model_tests/README.md
+++ b/model_tests/README.md
@@ -5,7 +5,9 @@ Here we will place the results from interacting with different models.
 # Grok Code Fast 1
  - Options Trading Trainer
 
-
 # Stage Plot Maker
  - Claude Code
  - Grok Code Fast 1
+
+# Codex
+ - 80s Racing Game


### PR DESCRIPTION
## Summary
- add Codex model test area with 80s_Racing_Game demo
- implement simple canvas racing game with keyboard controls
- update model tests listing

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b7f0a6f494832387002cd7123d6523